### PR TITLE
Fixed list formatting and rename UBOOT > FEL

### DIFF
--- a/source/includes/_advanced-headless.md
+++ b/source/includes/_advanced-headless.md
@@ -112,10 +112,13 @@ Simpler than the UART cable, you can connect to CHIP with a USB cable to your co
 ### Control CHIP Using a Serial Terminal
 
 Once you've connected CHIP to your computer with the UART or USB cable, open up a terminal. There's lots out there. Here's a few:
+
   * OS X: [Zterm](http://www.dalverson.com/zterm/), `screen` (built-in to OS X terminal)
   * Windows: [PuTTy](http://www.chipkin.com/using-putty-for-serial-com-connections-hyperterminal-replacement/) or [cygwin](https://cygwin.com)
   * Linux: `screen`, `cu`
+
 No matter the software, you'll need to set some settings for the port (aka connection). You'll probably only need to set the baud rate, as the others will be defaults:
+
   * Baud Rate (Data Rate): 115200
   * Data Bits: 8
   * Parity: none

--- a/source/includes/_advanced.md
+++ b/source/includes/_advanced.md
@@ -156,7 +156,7 @@ The original batch of CHIPs shipped with a software bug in the NAND flash storag
 
 
 #### Prepare CHIP for Flashing
-Prepare CHIP with a jumper wire connecting Pin 7 and Pin 39 on header U14 (UBOOT pin and GND). Here's a reference image that labels the headers and pins:
+Prepare CHIP with a jumper wire connecting Pin 7 and Pin 39 on header U14 (FEL pin and GND). Here's a reference image that labels the headers and pins:
 
 ![CHIP with jumper wire attached](images/uboot_jumper.jpg)
 


### PR DESCRIPTION
List was actually displayed inline instead of as a list.
At the setting up SDK/Flashing CHIP the tutorial states you need to connect a jumper with UBOOT and GND, whilst the pin actually says FEL instead of UBOOT. This caused confusion (at least it did for me) as there is no pin labeled UBOOT.